### PR TITLE
fix mt_srand php 7.1 change

### DIFF
--- a/src/Utilities/FisherYates.php
+++ b/src/Utilities/FisherYates.php
@@ -36,7 +36,9 @@ class FisherYates
         $secret = hexdec(substr(md5($secret), -6));
 
         // Seed the random number generator
-        mt_srand($secret);
+        version_compare(phpversion(),'7.1', '<') ?
+          mt_srand($secret) :
+          mt_srand($secret, MT_RAND_PHP);
 
         $shuffledArray = array();
         while (count($array) > 0) {
@@ -75,7 +77,9 @@ class FisherYates
         $secret = hexdec(substr(md5($secret), -6));
 
         // Seed the random number generator
-        mt_srand($secret);
+        version_compare(phpversion(),'7.1', '<') ?
+          mt_srand($secret) :
+          mt_srand($secret, MT_RAND_PHP);
 
         $keys = array();
         // Build the encoding keys


### PR DESCRIPTION
> ### Fixes to mt_rand() algorithm ¶
> mt_rand() will now default to using the fixed version of the Mersenne Twister algorithm. If deterministic 
> output from mt_srand() was relied upon, then the MT_RAND_PHP with the ability to preserve the old 
> (incorrect) implementation via an additional optional second parameter to mt_srand().
