### PR TITLE
Support PHP7.2 + Maintenance Tidy Up

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,12 @@
 language: php
 
 php:
-    - 5.4
-    - 5.5
     - 5.6
     - 7.0
     - 7.1
-    - hhvm
+    - 7.2
 
 matrix:
-    allow_failures:
-        - php: hhvm
     fast_finish: true
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,9 @@ php:
 matrix:
     fast_finish: true
 
-env:
-    global:
-        - CC_TEST_REPORTER_ID=0e07bda5ef4758c77750a5e56a98b90dd72a7e257fd52d3a814feb6ebb3923f
-        - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
-
 before_script:
-    - composer self-update && composer install
-    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
-    - chmod +x ./cc-test-reporter
-    - ./cc-test-reporter before-build
+    - composer self-update
+    - composer install
 
 script:
     - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,19 @@ php:
 matrix:
     fast_finish: true
 
-addons:
-    code_climate:
-        repo_token: 0e07bda5ef4758c77750a5e56a98b90dd72a7e257fd52d3a814feb6ebb3923f
+env:
+    global:
+        - CC_TEST_REPORTER_ID=0e07bda5ef4758c77750a5e56a98b90dd72a7e257fd52d3a814feb6ebb3923f
+        - GIT_COMMITTED_AT=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then git log -1 --pretty=format:%ct; else git log -1 --skip 1 --pretty=format:%ct; fi)
 
 before_script:
-    - composer self-update
-    - composer install
+    - composer self-update && composer install
+    - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+    - chmod +x ./cc-test-reporter
+    - ./cc-test-reporter before-build
 
 script:
-    - ./vendor/bin/phpunit
+    - make test
 
 after_script:
-    - ./vendor/bin/test-reporter --coverage-report coverage/clover.xml --stdout > codeclimate.json
-    - "curl -X POST -d @codeclimate.json -H 'Content-Type: application/json' -H 'User-Agent: Code Climate (PHP Test Reporter v0.1.1)' https://codeclimate.com/test_reports"
+    - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_script:
     - composer install
 
 script:
+    - make lint
     - make test
 
 after_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,18 @@
 Changelog
 ---------
 
+### Version 1.2.0 (10 Oct 2018)
+
+- Drop PHP < 5.6 support.
+- Add support for PHP 7.2.
+- Remove codeclimate test.
+- Add PHPCS.
+
+### Version 1.1.0 (18 Sept 2017)
+
+- Drop PHP5.3 support.
+- Specify mt_srand algorithm to maintain backwards compatibility from PHP 7.1 to earlier versions.
+
 ### Version 1.0.0 (22 Sept 2015)
 
 - Initial stable release.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+test:
+	./vendor/bin/phpunit

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,5 @@
 test:
 	./vendor/bin/phpunit
+
+lint:
+	./vendor/bin/phpcs

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ Developed by [Diarmuid](https://diarmuid.ie/).
 [![Latest Stable Version](https://poser.pugx.org/diarmuidie/niceid/v/stable)](https://packagist.org/packages/diarmuidie/niceid)
 [![License](https://poser.pugx.org/diarmuidie/niceid/license)](https://packagist.org/packages/diarmuidie/niceid)
 [![Build Status](https://travis-ci.org/diarmuidie/NiceID.svg)](https://travis-ci.org/diarmuidie/NiceID)
-[![Test Coverage](https://codeclimate.com/github/diarmuidie/niceid/badges/coverage.svg)](https://codeclimate.com/github/diarmuidie/niceid)
-[![Code Climate](https://codeclimate.com/github/diarmuidie/niceid/badges/gpa.svg)](https://codeclimate.com/github/diarmuidie/niceid)
 [![SensioLabsInsight](https://insight.sensiolabs.com/projects/319dfe53-d14e-478a-99e7-7f795fa33a2b/mini.png)](https://insight.sensiolabs.com/projects/319dfe53-d14e-478a-99e7-7f795fa33a2b)
 <!-- [![Total Downloads](https://poser.pugx.org/diarmuidie/niceid/downloads)](https://packagist.org/packages/diarmuidie/niceid) -->
 
@@ -20,7 +18,7 @@ Features
 - URL friendly.
 - No external dependencies.
 - PSR-4 compatible.
-- Compatible with PHP >= 5.4
+- Compatible with PHP >= 5.6
 
 Installation
 ------------

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,6 @@
     },
     "require-dev": {
         "phpunit/phpunit": ">=4.8.35 || ^5.7",
-        "codeclimate/php-test-reporter": "^0.4.4",
         "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -11,12 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=5.4"
+        "php": ">=5.6"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.5",
-        "squizlabs/php_codesniffer": "^2.0",
-        "codeclimate/php-test-reporter": "^0.1"
+        "phpunit/phpunit": ">=4.8.35 || ^5.7",
+        "codeclimate/php-test-reporter": "^0.4.4",
+        "squizlabs/php_codesniffer": "^3.3"
     },
     "autoload": {
         "psr-4": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+<ruleset name="PHP_CodeSniffer">
+    <file>./src</file>
+    <file>./tests</file>
+
+    <arg name="extensions" value="php" />
+    <arg name="colors"/>
+    <arg value="ps"/>
+
+    <rule ref="PSR2"/>
+</ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,7 @@
     </filter>
 
     <logging>
-        <log type="coverage-clover" target="coverage/clover.xml"/>
+        <log type="coverage-text" target="php://stdout"/>
+        <log type="coverage-html" target="coverage/"/>
     </logging>
 </phpunit>

--- a/src/NiceID.php
+++ b/src/NiceID.php
@@ -121,10 +121,8 @@ class NiceID implements NiceIDInterface
             );
         }
 
-        $characters = $this->characters;
-
         // Split characters string into array
-        $charactersArray = BaseConvert::mbStrSplit($characters);
+        $charactersArray = BaseConvert::mbStrSplit($this->characters);
 
         // Pick a random salt character
         $salt = $charactersArray[mt_rand(0, count($charactersArray) - 1)];
@@ -166,15 +164,13 @@ class NiceID implements NiceIDInterface
             );
         }
 
-        $characters = $this->characters;
-
         // Unshuffle the ID
         $niceIdArray = BaseConvert::mbStrSplit($niceId);
         $niceId = FisherYates::unshuffle($niceIdArray, $this->secret);
         $niceId = implode($niceId);
 
         // Split characters string into array
-        $charactersArray = BaseConvert::mbStrSplit($characters);
+        $charactersArray = BaseConvert::mbStrSplit($this->characters);
 
         $salt = $this->getSaltChar($niceId);
 

--- a/src/NiceID.php
+++ b/src/NiceID.php
@@ -51,7 +51,6 @@ class NiceID implements NiceIDInterface
         if ($secret !== null) {
             $this->secret = $secret;
         }
-
     }
 
     /**
@@ -63,7 +62,6 @@ class NiceID implements NiceIDInterface
     {
 
         $this->secret = $secret;
-
     }
 
     /**
@@ -75,7 +73,6 @@ class NiceID implements NiceIDInterface
     {
 
         $this->characters = $characters;
-
     }
 
     /**
@@ -87,7 +84,6 @@ class NiceID implements NiceIDInterface
     {
 
         $this->minLength = $minLength;
-
     }
 
     /**
@@ -100,7 +96,6 @@ class NiceID implements NiceIDInterface
 
         $maxID = PHP_INT_MAX - $this->minLengthAdder($this->characters, $this->minLength);
         return $maxID;
-
     }
 
     /**
@@ -153,7 +148,6 @@ class NiceID implements NiceIDInterface
         $niceId = implode($niceId);
 
         return $niceId;
-
     }
 
     /**
@@ -199,7 +193,6 @@ class NiceID implements NiceIDInterface
         }
 
         return $id;
-
     }
 
     /**
@@ -214,7 +207,6 @@ class NiceID implements NiceIDInterface
     {
 
         return pow(strlen($characters), $minLength - 2);
-
     }
 
     /**
@@ -229,7 +221,6 @@ class NiceID implements NiceIDInterface
 
         // Return the last char in the ID
         return mb_substr($niceID, -1);
-
     }
 
     /**
@@ -244,6 +235,5 @@ class NiceID implements NiceIDInterface
 
         // Return all but the last char in the ID
         return mb_substr($niceID, 0, -1);
-
     }
 }

--- a/src/Utilities/FisherYates.php
+++ b/src/Utilities/FisherYates.php
@@ -31,19 +31,11 @@ class FisherYates
      */
     public static function shuffle(array $array, $secret)
     {
-
-        // Hash the secret and convert to decimal
-        $secret = hexdec(substr(md5($secret), -6));
-
         // Seed the random number generator
-        version_compare(phpversion(),'7.1', '<') ?
-          mt_srand($secret) :
-          mt_srand($secret, MT_RAND_PHP);
+        self::seedRandomNumerGenerator($secret);
 
         $shuffledArray = array();
         while (count($array) > 0) {
-            // Seed the random number generator
-
             // Pick a random key from the original array
             $key = mt_rand(0, count($array) - 1);
 
@@ -73,13 +65,8 @@ class FisherYates
      */
     public static function unshuffle($shuffledArray, $secret)
     {
-        // Hash the secret and convert to decimal
-        $secret = hexdec(substr(md5($secret), -6));
-
         // Seed the random number generator
-        version_compare(phpversion(),'7.1', '<') ?
-          mt_srand($secret) :
-          mt_srand($secret, MT_RAND_PHP);
+        self::seedRandomNumerGenerator($secret);
 
         $keys = array();
         // Build the encoding keys
@@ -100,5 +87,24 @@ class FisherYates
         mt_srand();
 
         return $array;
+    }
+
+    /**
+     * Seed the random number generator using a secret string
+     *
+     * @param string $secret The secret
+     */
+    private static function seedRandomNumerGenerator($secret) {
+        // Hash the secret and convert to decimal
+        $secretDecimal = hexdec(substr(md5($secret), -6));
+
+        // @codeCoverageIgnoreStart
+        // Use the legacy MT_RAND_PHP Implementation in PHP > 7.1 .
+        // TODO: Switch to using the correct MT_RAND_MT19937 implementation
+        // in next major release (not backwards compatible).
+        version_compare(phpversion(),'7.1', '<') ?
+          mt_srand($secretDecimal) :
+          mt_srand($secretDecimal, MT_RAND_PHP);
+        // @codeCoverageIgnoreEnd
     }
 }

--- a/src/Utilities/FisherYates.php
+++ b/src/Utilities/FisherYates.php
@@ -53,7 +53,6 @@ class FisherYates
         mt_srand();
 
         return $shuffledArray;
-
     }
 
     /**
@@ -94,7 +93,8 @@ class FisherYates
      *
      * @param string $secret The secret
      */
-    private static function seedRandomNumerGenerator($secret) {
+    private static function seedRandomNumerGenerator($secret)
+    {
         // Hash the secret and convert to decimal
         $secretDecimal = hexdec(substr(md5($secret), -6));
 
@@ -102,7 +102,7 @@ class FisherYates
         // Use the legacy MT_RAND_PHP Implementation in PHP > 7.1 .
         // TODO: Switch to using the correct MT_RAND_MT19937 implementation
         // in next major release (not backwards compatible).
-        version_compare(phpversion(),'7.1', '<') ?
+        version_compare(phpversion(), '7.1', '<') ?
           mt_srand($secretDecimal) :
           mt_srand($secretDecimal, MT_RAND_PHP);
         // @codeCoverageIgnoreEnd

--- a/tests/NiceIDTest.php
+++ b/tests/NiceIDTest.php
@@ -12,6 +12,7 @@
 namespace Diarmuidie\NiceID\Tests;
 
 use Diarmuidie\NiceID\NiceID;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class NiceIDTest
@@ -22,7 +23,7 @@ use Diarmuidie\NiceID\NiceID;
  * @copyright 2015 Diarmuid
  * @license   http://www.opensource.org/licenses/MIT The MIT License
  */
-class NiceIDTest extends \PHPUnit_Framework_TestCase
+class NiceIDTest extends TestCase
 {
     private $niceid;
 
@@ -165,7 +166,7 @@ class NiceIDTest extends \PHPUnit_Framework_TestCase
         $this->niceid->setMinLength($under + 2);
         $this->niceid->encode(1);
 
-        $this->setExpectedException('LengthException');
+        $this->expectException('LengthException');
 
         // Length Exception
         $this->niceid->setMinLength($over + 2);
@@ -179,7 +180,7 @@ class NiceIDTest extends \PHPUnit_Framework_TestCase
     public function testNotIntEncodeException()
     {
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->niceid->encode('1');
 
     }
@@ -190,7 +191,7 @@ class NiceIDTest extends \PHPUnit_Framework_TestCase
     public function testNotScalarDecodeException()
     {
 
-        $this->setExpectedException('InvalidArgumentException');
+        $this->expectException('InvalidArgumentException');
         $this->niceid->decode(array());
 
     }

--- a/tests/NiceIDTest.php
+++ b/tests/NiceIDTest.php
@@ -49,7 +49,6 @@ class NiceIDTest extends TestCase
         $decodedInt = $this->niceid->decode($encoded);
 
         $this->assertEquals($int, $decodedInt);
-
     }
 
     /**
@@ -65,7 +64,6 @@ class NiceIDTest extends TestCase
 
         $decoded = $this->niceid->decode($niceID);
         $this->assertEquals($int, $decoded);
-
     }
 
     /**
@@ -93,7 +91,6 @@ class NiceIDTest extends TestCase
         $decodedInt = $this->niceid->decode($encoded);
 
         $this->assertEquals($decodedInt, $int);
-
     }
 
     /**
@@ -107,7 +104,6 @@ class NiceIDTest extends TestCase
         $niceid = new NiceID($testSecret);
 
         $this->assertAttributeEquals($testSecret, 'secret', $niceid);
-
     }
 
     /**
@@ -127,7 +123,6 @@ class NiceIDTest extends TestCase
         $this->assertEquals(mb_strlen($encoded), 2);
         $this->assertContains('a', $encoded);
         $this->assertContains('b', $encoded);
-
     }
 
     /**
@@ -147,7 +142,6 @@ class NiceIDTest extends TestCase
         $encoded = $this->niceid->encode(10);
 
         $this->assertGreaterThanOrEqual($minLength, strlen($encoded));
-
     }
 
     /**
@@ -171,7 +165,6 @@ class NiceIDTest extends TestCase
         // Length Exception
         $this->niceid->setMinLength($over + 2);
         $this->niceid->encode(1);
-
     }
 
     /**
@@ -182,7 +175,6 @@ class NiceIDTest extends TestCase
 
         $this->expectException('InvalidArgumentException');
         $this->niceid->encode('1');
-
     }
 
     /**
@@ -193,7 +185,6 @@ class NiceIDTest extends TestCase
 
         $this->expectException('InvalidArgumentException');
         $this->niceid->decode(array());
-
     }
 
     /**

--- a/tests/Utilities/BaseConvertTest.php
+++ b/tests/Utilities/BaseConvertTest.php
@@ -12,6 +12,7 @@
 namespace Diarmuidie\NiceID\Tests\Utilities;
 
 use Diarmuidie\NiceID\Utilities;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class NiceIDTest
@@ -22,7 +23,7 @@ use Diarmuidie\NiceID\Utilities;
  * @copyright 2015 Diarmuid
  * @license   http://www.opensource.org/licenses/MIT The MIT License
  */
-class BaseConvertTest extends \PHPUnit_Framework_TestCase
+class BaseConvertTest extends TestCase
 {
 
 

--- a/tests/Utilities/BaseConvertTest.php
+++ b/tests/Utilities/BaseConvertTest.php
@@ -43,7 +43,6 @@ class BaseConvertTest extends TestCase
         $convertedNumber = Utilities\BaseConvert::convert($fromNumber, $fromBase, $toBase);
 
         $this->assertEquals($toNumber, $convertedNumber);
-
     }
 
     /**
@@ -59,7 +58,9 @@ class BaseConvertTest extends TestCase
             array('g', 6, 'abcdefghi', '0123456789'),
             array(
                 '70B1D707EAC2EDF4C6389F440C7294B51FFF57BB',
-                '111000010110001110101110000011111101010110000101110110111110100110001100011100010011111010001000000110001110010100101001011010100011111111111110101011110111011',
+                '111000010110001110101110000011111101010110000101110110111110' .
+                  '1001100011000111000100111110100010000001100011100101001010' .
+                  '01011010100011111111111110101011110111011',
                 '0123456789ABCDEF',
                 '01'
             )

--- a/tests/Utilities/FisherYatesTest.php
+++ b/tests/Utilities/FisherYatesTest.php
@@ -49,7 +49,6 @@ class FisherYatesTest extends TestCase
         $shuffled = Utilities\FisherYates::shuffle($this->unShuffledArray, $this->testSecret);
 
         $this->assertEquals($shuffled, $this->shuffledArray);
-
     }
 
     /**
@@ -61,6 +60,5 @@ class FisherYatesTest extends TestCase
         $unShuffled = Utilities\FisherYates::unshuffle($this->shuffledArray, $this->testSecret);
 
         $this->assertEquals($unShuffled, $this->unShuffledArray);
-
     }
 }

--- a/tests/Utilities/FisherYatesTest.php
+++ b/tests/Utilities/FisherYatesTest.php
@@ -12,6 +12,7 @@
 namespace Diarmuidie\NiceID\Tests\Utilities;
 
 use Diarmuidie\NiceID\Utilities;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class NiceIDTest
@@ -22,7 +23,7 @@ use Diarmuidie\NiceID\Utilities;
  * @copyright 2015 Diarmuid
  * @license   http://www.opensource.org/licenses/MIT The MIT License
  */
-class FisherYatesTest extends \PHPUnit_Framework_TestCase
+class FisherYatesTest extends TestCase
 {
     /**
      * @var array Test unshuffled array


### PR DESCRIPTION
- Drop PHP < 5.6 support.
- Add support for PHP 7.2.
- Remove codeclimate test.
- Add PHPCS.